### PR TITLE
Raise error when smartctl not installed

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -80,6 +80,8 @@ class Device(object):
 
     def __init__(self, name, interface=None, abridged=False, smart_options=''):
         """Instantiates and initializes the `pySMART.device.Device`."""
+        if not SMARTCTL_PATH:
+            raise FileNotFoundError("Command smartctl doesn't exist!")
         if not (
             interface is None or
             interface.lower() in [


### PR DESCRIPTION
Raise FileNotFoundError when couldn't found smartctl installed on system.
https://github.com/truenas/py-SMART/issues/32