### PR TITLE
[Bug] Load device after trace logger as been configured

### DIFF
--- a/pySMART/__init__.py
+++ b/pySMART/__init__.py
@@ -102,11 +102,11 @@ portabiity, I thought a simple wrapper for smartctl would save time in the
 development of future automated test tools.
 """
 from .testentry import TestEntry
-from .device_list import DeviceList
-from .device import Device, smart_health_assement
 from .attribute import Attribute
 from . import utils
 utils.configure_trace_logging()
+from .device_list import DeviceList
+from .device import Device, smart_health_assement
 
 
 __version__ = '1.0.5'


### PR DESCRIPTION
as [device.py](https://github.com/truenas/py-SMART/blob/master/pySMART/device.py#L225) loads and uses the logger with the trace method, which does not exist until [configure_trace_logging()](https://github.com/truenas/py-SMART/blob/master/pySMART/utils.py#L82) has been called, hence when a 3rd party uses `DeviceList()`, it throws:
```
AttributeError: 'Logger' object has no attribute 'trace'
```

Regression introduced with: https://github.com/truenas/py-SMART/commit/5c43f7ad3316651fe9336ff87af3f8239290b306#diff-fe8e57b7ef9f83a2b30223dcbd4f4e9d3550e62efc34d3897f9891b1c42c3af8