### PR TITLE
Add vendor info to device

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -100,6 +100,8 @@ class Device(object):
         """**(str):** Device's model number."""
         self.serial: str = None
         """**(str):** Device's serial number."""
+        self.vendor: str = None
+        """**(str):** Device's vendor (if any)."""
         self.interface: str = None if interface == 'UNKNOWN INTERFACE' else interface
         """
         **(str):** Device's interface type. Must be one of:
@@ -875,6 +877,8 @@ class Device(object):
             if any_in(line, 'Serial Number', 'Serial number'):
                 self.serial = line.split(':')[1].split()[0].rstrip()
                 continue
+            if 'Vendor' in line:
+                self.vendor = line.split(':')[1].strip()
             if any_in(line, 'Firmware Version', 'Revision'):
                 self.firmware = line.split(':')[1].strip()
             if any_in(line, 'User Capacity', 'Namespace 1 Size/Capacity'):

--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -877,8 +877,9 @@ class Device(object):
             if any_in(line, 'Serial Number', 'Serial number'):
                 self.serial = line.split(':')[1].split()[0].rstrip()
                 continue
-            if 'Vendor' in line:
-                self.vendor = line.split(':')[1].strip()
+            vendor = re.compile(r'^Vendor:\s+(\w+)').match(line)
+            if vendor is not None:
+                self.vendor = vendor.groups()[0]
             if any_in(line, 'Firmware Version', 'Revision'):
                 self.firmware = line.split(':')[1].strip()
             if any_in(line, 'User Capacity', 'Namespace 1 Size/Capacity'):

--- a/tests/dataset/singletests/hdd_sata_issue42/device.json
+++ b/tests/dataset/singletests/hdd_sata_issue42/device.json
@@ -6,6 +6,7 @@
         "name": "sdau",
         "model": "OOS12000G",
         "serial": "00008AXB",
+        "vendor": null,
         "interface": "ata",
         "firmware": "OOS1",
         "smart_capable": true,

--- a/tests/dataset/singletests/issue_37_nvme_0/device.json
+++ b/tests/dataset/singletests/issue_37_nvme_0/device.json
@@ -6,6 +6,7 @@
         "name": "nvme0",
         "model": "Samsung SSD 970 EVO Plus 500GB",
         "serial": "S4EVNX0NA32843N",
+        "vendor": null,
         "interface": "nvme",
         "firmware": "2B2QEXM7",
         "smart_capable": true,

--- a/tests/dataset/singletests/macos_ssd_0/device.json
+++ b/tests/dataset/singletests/macos_ssd_0/device.json
@@ -6,6 +6,7 @@
         "name": "IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP06@1C,5/IOPP/SSD0@0/AppleAHCI/PRT0@0/IOAHCIDevice@0/AppleAHCIDiskDriver/IOAHCIBlockStorageDevice",
         "model": "APPLE SSD SM0256F",
         "serial": "S1XXXXXXXXXXXX",
+        "vendor": null,
         "interface": "ata",
         "firmware": "UXM2JA1Q",
         "smart_capable": true,

--- a/tests/dataset/singletests/megaraid_ph_sas_hdd_0/device.json
+++ b/tests/dataset/singletests/megaraid_ph_sas_hdd_0/device.json
@@ -6,6 +6,7 @@
         "name": "bus/7",
         "model": "HUS726040AL5210",
         "serial": "XXXXXXXX",
+        "vendor": "HGST",
         "interface": "megaraid,44",
         "firmware": "A907",
         "smart_capable": true,

--- a/tests/dataset/singletests/megaraid_ph_sata_hdd_0/device.json
+++ b/tests/dataset/singletests/megaraid_ph_sata_hdd_0/device.json
@@ -6,6 +6,7 @@
         "name": "bus/0",
         "model": "HGST HUS724040ALE640",
         "serial": "PKXXXXXXXXXXGB",
+        "vendor": null,
         "interface": "megaraid,16",
         "firmware": "MJAOA580",
         "smart_capable": true,

--- a/tests/dataset/singletests/megaraid_ph_sata_ssd_0/device.json
+++ b/tests/dataset/singletests/megaraid_ph_sata_ssd_0/device.json
@@ -6,6 +6,7 @@
         "name": "bus/0",
         "model": "INTEL SSDSC2BB120G6",
         "serial": "BXXXXXXXXXXXXXXXXN",
+        "vendor": null,
         "interface": "megaraid,28",
         "firmware": "G2010130",
         "smart_capable": true,

--- a/tests/dataset/singletests/megaraid_vd_0/device.json
+++ b/tests/dataset/singletests/megaraid_vd_0/device.json
@@ -5,6 +5,7 @@
         "name": "sda",
         "model": "RS3DC080",
         "serial": "00907d49075932d81f9044090ab00506",
+        "vendor": "Intel",
         "interface": "scsi",
         "firmware": "4.23",
         "smart_capable": false,

--- a/tests/dataset/singletests/nvme_test_0/device.json
+++ b/tests/dataset/singletests/nvme_test_0/device.json
@@ -5,6 +5,7 @@
         "name": "nvme0",
         "model": "KBG30ZMV256G TOSHIBA",
         "serial": "XXXXXXXXXXXX",
+        "vendor": null,
         "interface": "nvme",
         "firmware": "ADHA0101",
         "smart_capable": true,


### PR DESCRIPTION
Added support for reading the Vendor property from the information section. Below are two snippets from WD and Seagate drives that support this property:

```
=== START OF INFORMATION SECTION ===
Vendor:               Seagate
Product:              ST16000NM001G-2K
```

```
=== START OF INFORMATION SECTION ===
Vendor:               WDC
Product:              WD161KRYZ-01AGBB
```