### PR TITLE
Add sudo to Smartctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 1.2.0
+=============
+- Added "sudo" property to the Smartctl class for POSIX systems.
+- Added global SMARTCTL object used for defaults.
 
 Version 1.1.0
 =============

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ to be prompted for a password.
 >
 ```
 
+In general, it is recommended to run the base script with enough privileges to
+execute smartctl, but this is not possible in all cases, so this workaround is
+provided as a convenience. However, note that using sudo inside other
+non-terminal projects may cause dev-bugs/issues.
+
 Using the pySMART wrapper, Python applications be be rapidly developed to take
 advantage of the powerful features of smartmontools.
 
@@ -133,7 +138,7 @@ can be obtained through your package manager.  Likely one of the following::
 
 ```bash
 apt-get install smartmontools
-    or
+#    or
 yum install smartmontools
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,51 +27,94 @@ Usage
 The most common way to use pySMART is to create a logical representation of the
 physical storage device that you would like to work with, as shown::
 
-    >>> from pySMART import Device
-    >>> sda = Device('/dev/sda')
-    >>> sda
-    <SATA device on /dev/sda mod:WDC WD5000AAKS-60Z1A0 sn:WD-WCAWFxxxxxxx>
+
+```python
+>>> from pySMART import Device
+>>> sda = Device('/dev/sda')
+>>> sda
+<SATA device on /dev/sda mod:WDC WD5000AAKS-60Z1A0 sn:WD-WCAWFxxxxxxx>
+```
 
 ``Device`` class members can be accessed directly, and a number of helper methods
 are provided to retrieve information in bulk.  Some examples are shown below::
 
-    >>> sda.assessment  # Query the SMART self-assessment
-    'PASS'
-    >>> sda.attributes[9]  # Query a single SMART attribute
-    <SMART Attribute 'Power_On_Hours' 068/000 raw:23644>
-    >>> sda.all_attributes()  # Print the entire SMART attribute table
-    ID# ATTRIBUTE_NAME          CUR WST THR TYPE     UPDATED WHEN_FAIL    RAW
-      1 Raw_Read_Error_Rate     200 200 051 Pre-fail Always  -           0
-      3 Spin_Up_Time            141 140 021 Pre-fail Always  -           3908
-      4 Start_Stop_Count        098 098 000 Old_age  Always  -           2690
-      5 Reallocated_Sector_Ct   200 200 140 Pre-fail Always  -           0
-        ... # Edited for brevity
-    199 UDMA_CRC_Error_Count    200 200 000 Old_age  Always  -           0
-    200 Multi_Zone_Error_Rate   200 200 000 Old_age  Offline -           0
-    >>> sda.tests[0]  # Query the most recent self-test result
-    <SMART Self-test [Short offline|Completed without error] hrs:23734 LBA:->
-    >>> sda.all_selftests()  # Print the entire self-test log
-    ID Test_Description Status                        Left Hours  1st_Error@LBA
-     1 Short offline    Completed without error       00%  23734  -
-     2 Short offline    Completed without error       00%  23734  -
-       ... # Edited for brevity
-     7 Short offline    Completed without error       00%  23726  -
-     8 Short offline    Completed without error       00%  1      -
+```python
+>>> sda.assessment  # Query the SMART self-assessment
+'PASS'
+>>> sda.attributes[9]  # Query a single SMART attribute
+<SMART Attribute 'Power_On_Hours' 068/000 raw:23644>
+>>> sda.all_attributes()  # Print the entire SMART attribute table
+ID# ATTRIBUTE_NAME          CUR WST THR TYPE     UPDATED WHEN_FAIL    RAW
+  1 Raw_Read_Error_Rate     200 200 051 Pre-fail Always  -           0
+  3 Spin_Up_Time            141 140 021 Pre-fail Always  -           3908
+  4 Start_Stop_Count        098 098 000 Old_age  Always  -           2690
+  5 Reallocated_Sector_Ct   200 200 140 Pre-fail Always  -           0
+    ... # Edited for brevity
+199 UDMA_CRC_Error_Count    200 200 000 Old_age  Always  -           0
+200 Multi_Zone_Error_Rate   200 200 000 Old_age  Offline -           0
+>>> sda.tests[0]  # Query the most recent self-test result
+<SMART Self-test [Short offline|Completed without error] hrs:23734 LBA:->
+>>> sda.all_selftests()  # Print the entire self-test log
+ID Test_Description Status                        Left Hours  1st_Error@LBA
+ 1 Short offline    Completed without error       00%  23734  -
+ 2 Short offline    Completed without error       00%  23734  -
+   ... # Edited for brevity
+ 7 Short offline    Completed without error       00%  23726  -
+ 8 Short offline    Completed without error       00%  1      -
+```
 
 Alternatively, the package provides a ``DeviceList`` class. When instantiated,
 this will auto-detect all local storage devices and create a list containing
 one ``Device`` object for each detected storage device::
 
-    >>> from pySMART import DeviceList
-    >>> devlist = DeviceList()
-    >>> devlist
-    <DeviceList contents:
-    <SAT device on /dev/sdb mod:WDC WD20EADS-00R6B0 sn:WD-WCAVYxxxxxxx>
-    <SAT device on /dev/sdc mod:WDC WD20EADS-00S2B0 sn:WD-WCAVYxxxxxxx>
-    <CSMI device on /dev/csmi0,0 mod:WDC WD5000AAKS-60Z1A0 sn:WD-WCAWFxxxxxxx>
-    >
-    >>> devlist.devices[0].attributes[5]  # Access Device data as above
-    <SMART Attribute 'Reallocated_Sector_Ct' 173/140 raw:214>
+```python
+>>> from pySMART import DeviceList
+>>> devlist = DeviceList()
+>>> devlist
+<DeviceList contents:
+<SAT device on /dev/sdb mod:WDC WD20EADS-00R6B0 sn:WD-WCAVYxxxxxxx>
+<SAT device on /dev/sdc mod:WDC WD20EADS-00S2B0 sn:WD-WCAVYxxxxxxx>
+<CSMI device on /dev/csmi0,0 mod:WDC WD5000AAKS-60Z1A0 sn:WD-WCAWFxxxxxxx>
+>
+>>> devlist.devices[0].attributes[5]  # Access Device data as above
+<SMART Attribute 'Reallocated_Sector_Ct' 173/140 raw:214>
+```
+
+In the above cases if a new DeviceList is empty or a specific Device reports an
+"UNKNOWN INTERFACE", you are likely running without administrative privileges.
+On POSIX systems, you can request smartctl is run as a superuser by setting the
+sudo attribute of the global SMARTCTL object to True. Note this may cause you
+to be prompted for a password.
+
+
+```python
+>>> from pySMART import DeviceList
+>>> from pySMART import Device
+>>> sda = Device('/dev/sda')
+>>> sda
+<UNKNOWN INTERFACE device on /dev/sda mod:None sn:None>
+>>> devlist = DeviceList()
+>>> devlist
+<DeviceList contents:
+>
+>>> from pySMART import SMARTCTL
+>>> SMARTCTL.sudo = True
+>>> sda = Device('/dev/sda')
+>>> sda
+[sudo] password for user:
+<SAT device on /dev/sda mod:ST10000DM0004-1ZC101 sn:ZA20VNPT>
+>>> devlist = DeviceList()
+>>> devlist
+<DeviceList contents:
+<NVME device on /dev/nvme0 mod:Sabrent Rocket 4.0 1TB sn:03850709185D88300410>
+<NVME device on /dev/nvme1 mod:Samsung SSD 970 EVO Plus 2TB sn:S59CNM0RB05028D>
+<NVME device on /dev/nvme2 mod:Samsung SSD 970 EVO Plus 2TB sn:S59CNM0RB05113H>
+<SAT device on /dev/sda mod:ST10000DM0004-1ZC101 sn:ZA20VNPT>
+<SAT device on /dev/sdb mod:ST10000DM0004-1ZC101 sn:ZA22W366>
+<SAT device on /dev/sdc mod:ST10000DM0004-1ZC101 sn:ZA22SPLG>
+<SAT device on /dev/sdd mod:ST10000DM0004-1ZC101 sn:ZA2215HL>
+>
+```
 
 Using the pySMART wrapper, Python applications be be rapidly developed to take
 advantage of the powerful features of smartmontools.
@@ -80,15 +123,19 @@ Installation
 ============
 ``pySMART`` is available on PyPI and installable via ``pip``::
 
-    python -m pip install pySMART
+```bash
+python -m pip install pySMART
+```
 
 The only external (non-python) dependency is the ``smartctl`` component of the smartmontools
 package.  This should be pre-installed in most Linux distributions, or it
 can be obtained through your package manager.  Likely one of the following::
 
-    apt-get install smartmontools
-        or
-    yum install smartmontools
+```bash
+apt-get install smartmontools
+    or
+yum install smartmontools
+```
 
 On Windows PC's, smartmontools must be downloaded and installed.  The latest
 version can be obtained from the project's homepage, http://www.smartmontools.org/.

--- a/pySMART/__init__.py
+++ b/pySMART/__init__.py
@@ -117,6 +117,11 @@ to be prompted for a password.
     <SAT device on /dev/sdd mod:ST10000DM0004-1ZC101 sn:ZA2215HL>
     >
 
+In general, it is recommended to run the base script with enough privileges to
+execute smartctl, but this is not possible in all cases, so this workaround is
+provided as a convenience. However, note that using sudo inside other
+non-terminal projects may cause dev-bugs/issues.
+
 
 Using the pySMART wrapper, Python applications be be rapidly developed to take
 advantage of the powerful features of smartmontools.

--- a/pySMART/__init__.py
+++ b/pySMART/__init__.py
@@ -83,6 +83,41 @@ one `Device` object for each detected storage device.
     >>> devlist.devices[0].attributes[5]  # Access Device data as above
     <SMART Attribute 'Reallocated_Sector_Ct' 173/140 raw:214>
 
+In the above cases if a new DeviceList is empty or a specific Device reports an
+"UNKNOWN INTERFACE", you are likely running without administrative privileges.
+On POSIX systems, you can request smartctl is run as a superuser by setting the
+sudo attribute of the global SMARTCTL object to True. Note this may cause you
+to be prompted for a password.
+
+    #!bash
+    >>> from pySMART import DeviceList
+    >>> from pySMART import Device
+    >>> sda = Device('/dev/sda')
+    >>> sda
+    <UNKNOWN INTERFACE device on /dev/sda mod:None sn:None>
+    >>> devlist = DeviceList()
+    >>> devlist
+    <DeviceList contents:
+    >
+    >>> from pySMART import SMARTCTL
+    >>> SMARTCTL.sudo = True
+    >>> sda = Device('/dev/sda')
+    >>> sda
+    [sudo] password for user:
+    <SAT device on /dev/sda mod:ST10000DM0004-1ZC101 sn:ZA20VNPT>
+    >>> devlist = DeviceList()
+    >>> devlist
+    <DeviceList contents:
+    <NVME device on /dev/nvme0 mod:Sabrent Rocket 4.0 1TB sn:03850709185D88300410>
+    <NVME device on /dev/nvme1 mod:Samsung SSD 970 EVO Plus 2TB sn:S59CNM0RB05028D>
+    <NVME device on /dev/nvme2 mod:Samsung SSD 970 EVO Plus 2TB sn:S59CNM0RB05113H>
+    <SAT device on /dev/sda mod:ST10000DM0004-1ZC101 sn:ZA20VNPT>
+    <SAT device on /dev/sdb mod:ST10000DM0004-1ZC101 sn:ZA22W366>
+    <SAT device on /dev/sdc mod:ST10000DM0004-1ZC101 sn:ZA22SPLG>
+    <SAT device on /dev/sdd mod:ST10000DM0004-1ZC101 sn:ZA2215HL>
+    >
+
+
 Using the pySMART wrapper, Python applications be be rapidly developed to take
 advantage of the powerful features of smartmontools.
 
@@ -98,7 +133,7 @@ storage devices under Windows.  Without his work, my job would have been
 significantly more miserable. :)
 
 Having recently migrated my development from Batch to Python for Linux
-portabiity, I thought a simple wrapper for smartctl would save time in the
+portability, I thought a simple wrapper for smartctl would save time in the
 development of future automated test tools.
 """
 # autopep8: off
@@ -106,9 +141,14 @@ from .testentry import TestEntry
 from .attribute import Attribute
 from . import utils
 utils.configure_trace_logging()
+from .smartctl import SMARTCTL
 from .device_list import DeviceList
 from .device import Device, smart_health_assement
 # autopep8: on
 
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
+__all__ = [
+    'TestEntry', 'Attribute', 'utils', 'SMARTCTL', 'DeviceList', 'Device',
+    'smart_health_assement'
+]

--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -38,13 +38,13 @@ from typing import Tuple, Union, List, Dict
 from .attribute import Attribute
 from .diagnostics import Diagnostics
 from .testentry import TestEntry
-from .smartctl import Smartctl
+from .smartctl import Smartctl, SMARTCTL
 from .utils import smartctl_type, smartctl_isvalid_type, any_in, all_in
 
 logger = logging.getLogger('pySMART')
 
 
-def smart_health_assement(disk_name, smartctl: Smartctl = Smartctl()):
+def smart_health_assement(disk_name, smartctl: Smartctl = SMARTCTL):
     """
     This function gets the SMART Health Status of the disk (IF the disk
     is SMART capable and smart is enabled on it else returns None).
@@ -75,7 +75,7 @@ class Device(object):
     (considered SATA) but excludes other external devices (USB, Firewire).
     """
 
-    def __init__(self, name: str, interface: str = None, abridged: bool = False, smart_options: Union[str, List[str]] = None, smartctl: Smartctl = Smartctl()):
+    def __init__(self, name: str, interface: str = None, abridged: bool = False, smart_options: Union[str, List[str]] = None, smartctl: Smartctl = SMARTCTL):
         """Instantiates and initializes the `pySMART.device.Device`."""
         if not (
                 interface is None or

--- a/pySMART/device_list.py
+++ b/pySMART/device_list.py
@@ -29,7 +29,7 @@ import re
 
 # pySMART module imports
 from .device import Device
-from .smartctl import Smartctl
+from .smartctl import Smartctl, SMARTCTL
 from typing import List
 
 
@@ -38,7 +38,7 @@ class DeviceList(object):
     Represents a list of all the storage devices connected to this computer.
     """
 
-    def __init__(self, init: bool = True, smartctl=Smartctl()):
+    def __init__(self, init: bool = True, smartctl=SMARTCTL):
         """Instantiates and optionally initializes the `DeviceList`.
 
         Args:
@@ -46,8 +46,9 @@ class DeviceList(object):
                 is populated with `Device` objects during instantiation. Setting init
                 to False will skip initialization and create an empty
                 `pySMART.device_list.DeviceList` object instead. Defaults to True.
-            smartctl ([type], optional): This stablish the smartctl wrapper. Defaults to Smartctl()
-                and should be only overwritten on tests
+            smartctl ([type], optional): This stablish the smartctl wrapper.
+                Defaults the global `SMARTCTL` object and should be only
+                overwritten on tests.
         """
 
         self.devices: List[Device] = []

--- a/pySMART/diagnostics.py
+++ b/pySMART/diagnostics.py
@@ -21,9 +21,7 @@ represent SMART SCSI attributes associated with a `Device`.
 """
 
 import copy
-import re
 from typing import Dict
-from pySMART.utils import get_object_properties
 
 
 class Diagnostics(object):

--- a/pySMART/smartctl.py
+++ b/pySMART/smartctl.py
@@ -28,7 +28,7 @@ os.environ["LANG"] = "C"
 
 
 class Smartctl:
-    def __init__(self, smartctl_path=SMARTCTL_PATH, options: List[str] = [], sudo: Union[bool | List[str]] = False):
+    def __init__(self, smartctl_path=SMARTCTL_PATH, options: List[str] = [], sudo: Union[bool, List[str]] = False):
         """
         Instantiates and initializes the Smartctl wrapper.
 

--- a/pySMART/utils.py
+++ b/pySMART/utils.py
@@ -158,7 +158,6 @@ def smartctl_type(interface_type: str) -> str:
 
 
 def get_object_properties(obj: Any, deep_copy: bool = True, remove_private: bool = False) -> Dict[str, Any]:
-    type_name = type(obj).__name__
     prop_names = dir(obj)
 
     if deep_copy:


### PR DESCRIPTION
Hi, thanks for writing this tool. It saved me a lot of time.

Unfortunately I wasn't able to use it out of the box. The reason is that I don't install my Python packages in root-user space. I strictly keep everything in a local user virtual environment. This makes it tricky to execute smartctl.

Fortunately, if you simply prefix your Popen args with `sudo`, the terminal will do the "right thing" and prompt you for a sudo password if that session has not been authenticated yet. This allows the user to install pySMART without admin privileges, and request them only if needed.

The way I did this was I added a `sudo` property to the `Smartctl` class. When True is just adds sudo before calling Popen. I also made it such that if the system was non-posix, it will warn the user and ignore the setting.

I also had to make some small changes in order to make it easy for the user to enable this feature. I noticed that the `smartctl` attribute of DeviceList and Device  are defined at import time because the `SmartCtl` object is called in their `__init__` signature. This means that two global level instances are constructed anyway, so I figured why not just construct a single global instance, expose that to the user, and then use it instead. So I added a global `SMARTCTL` variable to the package, which is used as the default object for new Device and DeviceList constructions.

I added documentation for this new feature in the `__init__.py` and `README.md`. Also in the README, I changed the codeblock markdown syntax to use the one where you can specify a lexer for syntax highlighting. The "result" parts of the doctests are a bit noisy, but I think it overall looks better. Open to reverting that change though. You can preview what the new README would look like [here](https://github.com/Erotemic/py-SMART/blob/258760b75604896e45d55a49036c5c173e6d9d43/README.md). 

Lastly, I fixed a few spelling mistakes, removed some unused variables, bumped the minor version, added a CHANGELOG note.