### PR TITLE
Correctly handle attributes without threshold

### DIFF
--- a/pySMART/attribute.py
+++ b/pySMART/attribute.py
@@ -21,6 +21,7 @@ individual SMART attributes associated with a `Device`.
 """
 
 import re
+from typing import Optional
 
 
 class Attribute(object):
@@ -98,13 +99,13 @@ class Attribute(object):
         return int(self._worst)
 
     @property
-    def thresh(self) -> int:
+    def thresh(self) -> Optional[int]:
         """Gets the threshold value
 
         Returns:
             int: The attribute threshold field in integer format
         """
-        return int(self._thresh)
+        return None if self._thresh == '---' else int(self._thresh)
 
     @property
     def raw_int(self) -> int:


### PR DESCRIPTION
Under some circumstances, smartctl reports attribute thresholds as '---' which previously caused a ValueError.

This patch sets the thresh property to None in that case.

The setup is a Raspbian 10 with smartctl 6.6 and a Western Digital SSD (Model: SA530) attached via a USB bridge. The full output of `smartctl -A` is as follows:
```
smartctl 6.6 2017-11-05 r4594 [armv7l-linux-5.10.103-v7l+] (local build)
Copyright (C) 2002-17, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
SMART Attributes Data Structure revision number: 4
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  5 Reallocated_Sector_Ct   0x0032   100   100   ---    Old_age   Always       -       0
  9 Power_On_Hours          0x0032   100   100   ---    Old_age   Always       -       20379
 12 Power_Cycle_Count       0x0032   100   100   ---    Old_age   Always       -       5
165 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       120193844
166 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       1
167 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       34
168 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       5
169 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       328
170 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       0
171 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       0
172 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       0
173 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       2
174 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       1
184 End-to-End_Error        0x0032   100   100   ---    Old_age   Always       -       0
187 Reported_Uncorrect      0x0032   100   100   ---    Old_age   Always       -       0
188 Command_Timeout         0x0032   100   100   ---    Old_age   Always       -       1
194 Temperature_Celsius     0x0022   067   039   ---    Old_age   Always       -       33 (Min/Max 18/39)
199 UDMA_CRC_Error_Count    0x0032   100   100   ---    Old_age   Always       -       0
230 Unknown_SSD_Attribute   0x0032   001   001   ---    Old_age   Always       -       1374390845760
232 Available_Reservd_Space 0x0033   100   100   004    Pre-fail  Always       -       100
233 Media_Wearout_Indicator 0x0032   100   100   ---    Old_age   Always       -       1053
234 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       9459
241 Total_LBAs_Written      0x0030   253   253   ---    Old_age   Offline      -       3891
242 Total_LBAs_Read         0x0030   253   253   ---    Old_age   Offline      -       19010
244 Unknown_Attribute       0x0032   000   100   ---    Old_age   Always       -       0
```