### PR TITLE
Fixed missing interface subpackage in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = ["setuptools", "setuptools-scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ['pySMART']
+packages = ['pySMART', 'pySMART.interface']
 
 [tool.setuptools_scm]
 write_to = "pySMART/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@
 requires = ["setuptools", "setuptools-scm[toml]"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ['pySMART', 'pySMART.interface']
+[tool.setuptools.packages.find]
+include = ["pySMART*"]
 
 [tool.setuptools_scm]
 write_to = "pySMART/version.py"


### PR DESCRIPTION
Hi, I'm the maintainer of the [python-pysmart](https://aur.archlinux.org/packages/python-pysmart) package in the [Arch User Repository](https://aur.archlinux.org/). While updating it to 1.2.4, I've noticed that the new PEP 517-based build flow doesn't seem to include the `interface` subpackage in the resulting wheel file:
```python
>>> from pySMART import Device
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.10/site-packages/pySMART/__init__.py", line 150, in <module>
    from .device_list import DeviceList
  File "/usr/lib/python3.10/site-packages/pySMART/device_list.py", line 31, in <module>
    from .device import Device
  File "/usr/lib/python3.10/site-packages/pySMART/device.py", line 40, in <module>
    from .interface import *
ModuleNotFoundError: No module named 'pySMART.interface'
```

This PR explicity adds it to the list of packages, which causes it to be included in the wheel file:
```python
>>> from pySMART import Device
>>> Device('/dev/nvme0n1')
<NVME device on /dev/nvme0n1 mod:XPG GAMMIX S11 Pro sn:2L012L1H9AK2>
```