### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/pySMART/device_list.py
+++ b/pySMART/device_list.py
@@ -113,7 +113,7 @@ class DeviceList(object):
         for line in self.smartctl.scan():
             if not ('failed:' in line or line == ''):
                 groups = re.compile(
-                    '^(\S+)\s+-d\s+(\S+)').match(line).groups()
+                    r'^(\S+)\s+-d\s+(\S+)').match(line).groups()
                 name = groups[0]
                 interface = groups[1]
 


### PR DESCRIPTION
This fixes the following deprecation warning:

```
pySMART/device_list.py:116
  /home/yoshi/Downloads/py-SMART/pySMART/device_list.py:116: DeprecationWarning: invalid escape sequence 'S'
    '^(\S+)\s+-d\s+(\S+)').match(line).groups()
```