### PR TITLE
Allow for empty serial.

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -1075,7 +1075,11 @@ class Device(object):
                 continue
 
             if any_in(line, 'Serial Number', 'Serial number'):
-                self.serial = line.split(':')[1].split()[0].rstrip()
+                try:
+                    self.serial = line.split(':')[1].split()[0].rstrip()
+                except IndexError:
+                    # Serial reported empty
+                    self.serial = ""
                 continue
 
             vendor = re.compile(r'^Vendor:\s+(\w+)').match(line)


### PR DESCRIPTION
I have several NVME drives reporting an empty 'Serial Number:'. The line is there, but with no data. This commit catches that error. I was in doubt if it might have been nicer to check the length returned by the split(':').